### PR TITLE
Enables suppression for Blender naming convention

### DIFF
--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/inspection/BlenderPropertySuppressor.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/inspection/BlenderPropertySuppressor.kt
@@ -62,6 +62,9 @@ class BlenderPropertySuppressor : InspectionSuppressor {
         val text = callee.text ?: return false
         val name = callee.referencedName ?: return false
 
+        // Accept strict "bpy.props.*" prefix OR simple name match as a fallback.
+        // Fallback is needed for cases like "from bpy.props import StringProperty" where resolution fails.
+        // Note: This matches any function with these names, creating a potential false positive trade-off.
         return text.startsWith("bpy.props.") || name in BLENDER_PROPS
     }
 


### PR DESCRIPTION
Extends the inspection suppressor to handle Blender's specific naming convention for classes.

This prevents false positives for naming violations related to Blender's style, improving code analysis accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce false naming warnings by recognizing Blender-style class names and suppressing naming inspections for them.
  * Improve detection of Blender property usages (including qualified bpy.props references), so property-related inspections are correctly suppressed.
* **Chores**
  * Broadened the set of inspection checks covered by suppression to avoid spurious alerts and streamline rule handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->