### PR TITLE
Generates full bpy.ops stubs

### DIFF
--- a/src/main/resources/python/generate_stubs.py
+++ b/src/main/resources/python/generate_stubs.py
@@ -403,20 +403,26 @@ class StubGenerator:
             ops_in_cat = []
             for op_name in dir(cat_obj):
                 if op_name.startswith("__"): continue
-
                 op_func = getattr(cat_obj, op_name)
                 rna = getattr(op_func, "get_rna_type", lambda: None)()
 
                 if rna:
-                    args_sig = ["override_context: Optional[Union[Dict, 'bpy.types.Context']] = None",
-                                "execution_context: Optional[str] = None",
-                                "undo: Optional[bool] = None"]
+                    args_sig = [
+                        "override_context: Optional[Union[Dict, 'bpy.types.Context']] = None",
+                        "execution_context: Optional[str] = None",
+                        "undo: Optional[bool] = None"
+                    ]
 
+                    kw_args = []
                     for prop in rna.properties:
                         if prop.identifier == "rna_type": continue
                         arg_name = self.sanitize_arg_name(prop.identifier)
                         arg_type = self.map_rna_type(prop)
-                        args_sig.append(f"*, {arg_name}: {arg_type} = ...")
+                        kw_args.append(f"{arg_name}: {arg_type} = ...")
+
+                    if kw_args:
+                        args_sig.append("*")
+                        args_sig.extend(kw_args)
 
                     sig_str = ", ".join(args_sig)
                     doc = self.format_docstring(rna.description) if rna.description else ""


### PR DESCRIPTION
Adds functionality to generate complete stubs for the bpy.ops module, providing detailed type hints and documentation for each operator. This enhances code completion and helps to discover available operations within Blender's API.

Adds a helper function to sanitize argument names to avoid collisions with Python keywords.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Python stub generation with automatic handling of reserved keyword argument names.
  * Refined bpy.ops stub generation workflow to produce more complete, consistent per-category stubs and aggregated module listings.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->