### PR TITLE
Support IntelliJ 2026.1 debugger API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-22
+
+### Changed
+
+* **Internal API Changes**:
+  * Support JetBrains 2026.1 debugger API maintaining compatibility with 2025.3.
+
+## [0.1.8] - 2026-03-05
+
 ### Changed
 
 * **Stub Generation Enhancement**:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 <!-- Plugin description -->
 **Blender Probe** bridges PyCharm and Blender with **Code Completion**, **Testing**, **Debugging**, and **Hot Reloading**.
 
-> **⚠️ Compatibility Note: (Public Beta)**
-> While **Blender Probe** is designed to work across Windows, macOS, and Linux, primary development and extensive testing have been conducted on **macOS**.
-> Windows and Linux support is currently **experimental**. If you encounter any pathing issues or unexpected behavior on these platforms, please [open an issue](https://github.com/unclepomedev/blender_probe_for_pycharm/issues).
-
 ## Features
 
 * **Dynamic API Stubs (Experimental)**: Generates Python type `.pyi` stubs (including daily builds) via runtime introspection.
@@ -18,7 +14,8 @@
 * **Integrated Test Runner**: Run standard `unittest` suites inside Blender from PyCharm's UI.
 * **Project Wizard**: Scaffolds a Blender 4.2+ Extensions compliant project.
 
-Detailed description: [GitHub Repository](https://github.com/unclepomedev/blender_probe_for_pycharm)
+Detailed description and Issues: [GitHub Repository](https://github.com/unclepomedev/blender_probe_for_pycharm)
+
 <!-- Plugin description end -->
 
 ## Configuration & Usage

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.unclepomedev.blenderprobeforpycharm
 pluginName = Blender Probe
 pluginRepositoryUrl = https://github.com/unclepomedev/blender_probe_for_pycharm
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.8
+pluginVersion = 0.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 253

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
@@ -17,18 +17,16 @@ import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
-import com.intellij.xdebugger.XDebugProcess
-import com.intellij.xdebugger.XDebugProcessStarter
-import com.intellij.xdebugger.XDebugSession
-import com.intellij.xdebugger.XDebuggerManager
-import com.intellij.xdebugger.XDebugSessionListener
+import com.intellij.xdebugger.*
 import com.jetbrains.python.debugger.PyDebugProcess
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 import java.net.ServerSocket
 
 /**
@@ -36,7 +34,9 @@ import java.net.ServerSocket
  * Supports both Run and Debug modes. In Debug mode, it attaches the Python debugger.
  */
 class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
+
     override fun getRunnerId(): String = "BlenderRunner"
+    private val log = Logger.getInstance(BlenderRunner::class.java)
 
     /**
      * Checks if the runner can execute the given run profile.
@@ -140,8 +140,10 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
             if (isAtLeast2026()) {
                 try {
                     return debugSession2026(manager, environment, processStarter)
-                } catch (e: Exception) {
-                    System.err.println("Blender Probe: Failed to use 2026.X Debugger API, falling back to legacy API. Error: ${e.message}")
+                } catch (e: InvocationTargetException) {
+                    throw e.targetException
+                } catch (e: ReflectiveOperationException) {
+                    log.error("Blender Probe: Failed to use 2026.X Debugger API, falling back to legacy API. Error: ${e.message}")
                 }
             }
             // 2025.x or fallback
@@ -162,10 +164,12 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
     ): RunContentDescriptor {
         val builder = manager.javaClass.getMethod("newSessionBuilder", XDebugProcessStarter::class.java)
             .invoke(manager, processStarter)
-        builder.javaClass.getMethod("environment", ExecutionEnvironment::class.java)
-            .invoke(builder, environment)
-        val result = builder.javaClass.getMethod("startSession").invoke(builder)
-        return result.javaClass.getMethod("getRunContentDescriptor").invoke(result) as RunContentDescriptor
+        val environmentMethod = builder.javaClass.getMethod("environment", ExecutionEnvironment::class.java)
+        val startSessionMethod = builder.javaClass.getMethod("startSession")
+        val descriptorMethod = startSessionMethod.returnType.getMethod("getRunContentDescriptor")
+        environmentMethod.invoke(builder, environment)
+        val result = startSessionMethod.invoke(builder)
+        return descriptorMethod.invoke(result) as RunContentDescriptor
     }
 
     @Suppress("DEPRECATION")

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
@@ -14,6 +14,7 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.RunContentBuilder
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.extensions.PluginId
@@ -111,43 +112,70 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
         return RunContentBuilder(executionResult, environment).showRunContent(environment.contentToReuse)
     }
 
-    @Suppress("DEPRECATION")
     private fun startDebugSession(state: BlenderRunningState, environment: ExecutionEnvironment): RunContentDescriptor {
         val serverSocket = ServerSocket(0)
         var createdProcessHandler: ProcessHandler? = null
+        val project = environment.project
+
+        val processStarter = object : XDebugProcessStarter() {
+            override fun start(session: XDebugSession): XDebugProcess {
+                val executionResult = state.execute(environment.executor, this@BlenderRunner)
+                createdProcessHandler = executionResult.processHandler
+                session.addSessionListener(object : XDebugSessionListener {
+                    override fun sessionStopped() {
+                        createdProcessHandler?.takeUnless { it.isProcessTerminated }?.destroyProcess()
+                        if (!serverSocket.isClosed) serverSocket.close()
+                    }
+                })
+                return PyDebugProcess(
+                    session, serverSocket, executionResult.executionConsole,
+                    executionResult.processHandler, false
+                )
+            }
+        }
 
         try {
             state.debugPort = serverSocket.localPort
-
-            val session = XDebuggerManager.getInstance(environment.project)
-                .startSession(environment, object : XDebugProcessStarter() {
-                    override fun start(session: XDebugSession): XDebugProcess {
-                        val executionResult = state.execute(environment.executor, this@BlenderRunner)
-                        createdProcessHandler = executionResult.processHandler
-                        session.addSessionListener(object : XDebugSessionListener {
-                            override fun sessionStopped() {
-                                createdProcessHandler?.takeUnless { it.isProcessTerminated }?.destroyProcess()
-                            }
-                        })
-                        return PyDebugProcess(
-                            session,
-                            serverSocket,
-                            executionResult.executionConsole,
-                            executionResult.processHandler,
-                            false
-                        )
-                    }
-                })
-
-            return session.runContentDescriptor
+            val manager = XDebuggerManager.getInstance(project)
+            if (isAtLeast2026()) {
+                try {
+                    return debugSession2026(manager, environment, processStarter)
+                } catch (e: Exception) {
+                    System.err.println("Blender Probe: Failed to use 2026.X Debugger API, falling back to legacy API. Error: ${e.message}")
+                }
+            }
+            // 2025.x or fallback
+            return debugSession2025(manager, environment, processStarter)
 
         } catch (e: Exception) {
             createdProcessHandler?.takeUnless { it.isProcessTerminated }?.destroyProcess()
-            if (!serverSocket.isClosed) {
-                serverSocket.close()
-            }
+            if (!serverSocket.isClosed) serverSocket.close()
             throw e
         }
+    }
+
+    //TODO: (HACK) using reflection to get the 2025 version to compile. change the implementation once drop the 2025 version.
+    private fun debugSession2026(
+        manager: XDebuggerManager,
+        environment: ExecutionEnvironment,
+        processStarter: XDebugProcessStarter
+    ): RunContentDescriptor {
+        val builder = manager.javaClass.getMethod("newSessionBuilder", XDebugProcessStarter::class.java)
+            .invoke(manager, processStarter)
+        builder.javaClass.getMethod("environment", ExecutionEnvironment::class.java)
+            .invoke(builder, environment)
+        val result = builder.javaClass.getMethod("startSession").invoke(builder)
+        return result.javaClass.getMethod("getRunContentDescriptor").invoke(result) as RunContentDescriptor
+    }
+
+    @Suppress("DEPRECATION")
+    private fun debugSession2025(
+        manager: XDebuggerManager,
+        environment: ExecutionEnvironment,
+        processStarter: XDebugProcessStarter
+    ): RunContentDescriptor {
+        val session = manager.startSession(environment, processStarter)
+        return session.runContentDescriptor
     }
 
     private fun findPydevdPath(): String? {
@@ -177,5 +205,10 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
         }
 
         return null
+    }
+
+    private fun isAtLeast2026(): Boolean {
+        val build = ApplicationInfo.getInstance().build
+        return build.baselineVersion >= 261
     }
 }

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
@@ -124,7 +124,11 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
                 session.addSessionListener(object : XDebugSessionListener {
                     override fun sessionStopped() {
                         createdProcessHandler?.takeUnless { it.isProcessTerminated }?.destroyProcess()
-                        if (!serverSocket.isClosed) serverSocket.close()
+                        try {
+                            if (!serverSocket.isClosed) serverSocket.close()
+                        } catch (e: Exception) {
+                            log.warn("Failed to close debug server socket", e)
+                        }
                     }
                 })
                 return PyDebugProcess(
@@ -169,7 +173,8 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
         val descriptorMethod = startSessionMethod.returnType.getMethod("getRunContentDescriptor")
         environmentMethod.invoke(builder, environment)
         val result = startSessionMethod.invoke(builder)
-        return descriptorMethod.invoke(result) as RunContentDescriptor
+        return descriptorMethod.invoke(result) as? RunContentDescriptor
+            ?: throw ExecutionException("Debug session started but returned no content descriptor")
     }
 
     @Suppress("DEPRECATION")

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
@@ -147,7 +147,7 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
                 } catch (e: InvocationTargetException) {
                     throw e.targetException
                 } catch (e: ReflectiveOperationException) {
-                    log.error("Blender Probe: Failed to use 2026.X Debugger API, falling back to legacy API. Error: ${e.message}")
+                    log.warn("Blender Probe: 2026.X Debugger API unavailable, using legacy API. Error: ${e.message}")
                 }
             }
             // 2025.x or fallback
@@ -155,7 +155,11 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
 
         } catch (e: Exception) {
             createdProcessHandler?.takeUnless { it.isProcessTerminated }?.destroyProcess()
-            if (!serverSocket.isClosed) serverSocket.close()
+            try {
+                if (!serverSocket.isClosed) serverSocket.close()
+            } catch (closeEx: Exception) {
+                e.addSuppressed(closeEx)
+            }
             throw e
         }
     }


### PR DESCRIPTION
close #62 

Implement version-aware debug session initialization to handle the new XDebuggerManager API in IntelliJ 2026.1 (baseline 261+). Use reflection to call the new session builder to maintain backward compatibility with 2025.x and ensure that debug server sockets are properly closed when sessions terminate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compatibility path for newer IDE debugger API to support recent IDE releases

* **Bug Fixes**
  * Improved socket cleanup to prevent resource leaks when debug sessions stop
  * Safer error handling with automatic fallback to legacy startup when newer flow fails

* **Refactor**
  * Reworked debug session startup to branch by IDE version for more reliable startup/shutdown

* **Documentation**
  * Updated changelog and README; bumped plugin version

* **Style**
  * Minor formatting and end-of-file cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->