### PR TITLE
Update minimum PyCharm version to 2026.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-19
+
+### Changed
+
+- Minimum required PyCharm version is now 2026.1 (was 2025.3).
+  This is required to use the redesigned platform debugger API introduced in 2026.1 and to avoid the now-internal `PluginManagerCore.getPlugin()` API.
+
 ## [0.2.0] - 2026-03-22
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-## Automated Code Review
-
-This project utilizes **CodeRabbit AI** to assist with code reviews. Its purpose is to catch potential bugs and suggest improvements early in the process.
-
-However, AI suggestions should be treated as **optional advice**, not mandatory requirements.
-* If the AI makes a mistake or gives a false positive, please disregard it or explain why in the comments.
-* **Final decisions are always made by human reviewers.** Do not feel pressured to implement every suggestion made by the bot.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 <!-- Plugin description -->
 **Blender Probe** bridges PyCharm and Blender with **Code Completion**, **Testing**, **Debugging**, and **Hot Reloading**.
 
+## Requirements
+
+PyCharm 2026.1 or later.
+
 ## Features
 
 * **Dynamic API Stubs (Experimental)**: Generates Python type `.pyi` stubs (including daily builds) via runtime introspection.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 
 plugins {
     id("java")
@@ -76,6 +77,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")
+            // The `untilBuild` parameter is intentionally not specified.
         }
     }
 
@@ -92,7 +94,10 @@ intellijPlatform {
     pluginVerification {
         ides {
             select {
-                types = listOf(IntelliJPlatformType.PyCharmCommunity, IntelliJPlatformType.PyCharmProfessional)
+                types = listOf(IntelliJPlatformType.PyCharmProfessional)
+                channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
+                sinceBuild = "261"
+                untilBuild = "999.*"
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.unclepomedev.blenderprobeforpycharm
 pluginName = Blender Probe
 pluginRepositoryUrl = https://github.com/unclepomedev/blender_probe_for_pycharm
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.0
+pluginVersion = 0.3.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,10 @@ pluginRepositoryUrl = https://github.com/unclepomedev/blender_probe_for_pycharm
 pluginVersion = 0.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 253
+pluginSinceBuild = 261
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformVersion = 2025.3.2
+platformVersion = 2026.1.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunner.kt
@@ -13,20 +13,19 @@ import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.RunContentBuilder
 import com.intellij.execution.ui.RunContentDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
-import com.intellij.xdebugger.*
+import com.intellij.xdebugger.XDebugProcess
+import com.intellij.xdebugger.XDebugProcessStarter
+import com.intellij.xdebugger.XDebugSession
+import com.intellij.xdebugger.XDebugSessionListener
+import com.intellij.xdebugger.XDebuggerManager
+import com.jetbrains.python.PythonHelper
 import com.jetbrains.python.debugger.PyDebugProcess
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
-import java.io.File
-import java.lang.reflect.InvocationTargetException
 import java.net.ServerSocket
 
 /**
@@ -78,15 +77,12 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
                     state.cachedSourceRoot = BlenderProbeUtils.getAddonSourceRoot(project) ?: project.basePath
                 }
                 if (environment.executor.id == DefaultDebugExecutor.EXECUTOR_ID) {
-                    val pydevd = findPydevdPath()
-                        ?: throw ExecutionException("Could not find 'pydevd'. Debugging not possible.")
-                    state.pydevdPath = pydevd
+                    state.pydevdPath = PythonHelper.DEBUGGER.pythonPathEntry
                 }
             }
 
             override fun onSuccess() {
                 if (promise.state == Promise.State.REJECTED) return
-
                 try {
                     val descriptor = if (environment.executor.id == DefaultDebugExecutor.EXECUTOR_ID) {
                         startDebugSession(state, environment)
@@ -112,7 +108,10 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
         return RunContentBuilder(executionResult, environment).showRunContent(environment.contentToReuse)
     }
 
-    private fun startDebugSession(state: BlenderRunningState, environment: ExecutionEnvironment): RunContentDescriptor {
+    private fun startDebugSession(
+        state: BlenderRunningState,
+        environment: ExecutionEnvironment
+    ): RunContentDescriptor {
         val serverSocket = ServerSocket(0)
         var createdProcessHandler: ProcessHandler? = null
         val project = environment.project
@@ -140,18 +139,14 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
 
         try {
             state.debugPort = serverSocket.localPort
-            val manager = XDebuggerManager.getInstance(project)
-            if (isAtLeast2026()) {
-                try {
-                    return debugSession2026(manager, environment, processStarter)
-                } catch (e: InvocationTargetException) {
-                    throw e.targetException
-                } catch (e: ReflectiveOperationException) {
-                    log.warn("Blender Probe: 2026.X Debugger API unavailable, using legacy API.", e)
-                }
-            }
-            // 2025.x or fallback
-            return debugSession2025(manager, environment, processStarter)
+            @Suppress("UnstableApiUsage")  // newSessionBuilder is experimental
+            val session = XDebuggerManager.getInstance(project)
+                .newSessionBuilder(processStarter)
+                .environment(environment)
+                .startSession()
+            @Suppress("UnstableApiUsage")  // getRunContentDescriptor is experimental
+            return session.runContentDescriptor
+                ?: throw ExecutionException("Debug session started but returned no content descriptor")
 
         } catch (e: Exception) {
             createdProcessHandler?.takeUnless { it.isProcessTerminated }?.destroyProcess()
@@ -162,66 +157,5 @@ class BlenderRunner : AsyncProgramRunner<RunnerSettings>() {
             }
             throw e
         }
-    }
-
-    //TODO: (HACK) using reflection to get the 2025 version to compile. change the implementation once drop the 2025 version.
-    private fun debugSession2026(
-        manager: XDebuggerManager,
-        environment: ExecutionEnvironment,
-        processStarter: XDebugProcessStarter
-    ): RunContentDescriptor {
-        val builder = manager.javaClass.getMethod("newSessionBuilder", XDebugProcessStarter::class.java)
-            .invoke(manager, processStarter)
-        val environmentMethod = builder.javaClass.getMethod("environment", ExecutionEnvironment::class.java)
-        val startSessionMethod = builder.javaClass.getMethod("startSession")
-        val descriptorMethod = startSessionMethod.returnType.getMethod("getRunContentDescriptor")
-        environmentMethod.invoke(builder, environment)
-        val result = startSessionMethod.invoke(builder)
-        return descriptorMethod.invoke(result) as? RunContentDescriptor
-            ?: throw ExecutionException("Debug session started but returned no content descriptor")
-    }
-
-    @Suppress("DEPRECATION")
-    private fun debugSession2025(
-        manager: XDebuggerManager,
-        environment: ExecutionEnvironment,
-        processStarter: XDebugProcessStarter
-    ): RunContentDescriptor {
-        val session = manager.startSession(environment, processStarter)
-        return session.runContentDescriptor
-    }
-
-    private fun findPydevdPath(): String? {
-        val pluginIds = listOf("Pythonid", "PythonCore", "python-ce", "python")
-
-        for (id in pluginIds) {
-            val pluginId = PluginId.getId(id)
-            val plugin = PluginManagerCore.getPlugin(pluginId)
-
-            if (plugin != null && !PluginManagerCore.isDisabled(pluginId)) {
-                val path = plugin.pluginPath.resolve("helpers/pydev").toFile()
-                if (path.exists()) return path.absolutePath
-            }
-        }
-
-        val possiblePaths = listOf(
-            File(PathManager.getHomePath(), "plugins/python/helpers/pydev"),
-            File(PathManager.getHomePath(), "plugins/python-ce/helpers/pydev"),
-            File(PathManager.getHomePath(), "plugins/PythonCore/helpers/pydev"),
-            File(PathManager.getHomePath(), "Contents/plugins/python/helpers/pydev"),
-            File(PathManager.getHomePath(), "Contents/plugins/python-ce/helpers/pydev"),
-            File(PathManager.getHomePath(), "Contents/plugins/PythonCore/helpers/pydev")
-        )
-
-        for (path in possiblePaths) {
-            if (path.exists()) return path.absolutePath
-        }
-
-        return null
-    }
-
-    private fun isAtLeast2026(): Boolean {
-        val build = ApplicationInfo.getInstance().build
-        return build.baselineVersion >= 261
     }
 }


### PR DESCRIPTION
- Leverage the redesigned platform debugger API and `PythonHelper.DEBUGGER.pythonPathEntry`.
- Remove usage of deprecated internal `PluginManagerCore.getPlugin()` and custom `pydevd` path detection.
- Delete `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to target PyCharm 2026.1.

* **Documentation**
  * Added Requirements section specifying PyCharm 2026.1 or later in README.
  * Updated CHANGELOG with new 0.3.0 release information.
  * Removed Automated Code Review section from contribution guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unclepomedev/blender_probe_for_pycharm/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->