### PR TITLE
Fix blender communication breaking upon new blend file load

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,23 @@ jobs:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
 
+  pythonTest:
+    name: Python tests
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Fetch Sources
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6
+        with:
+          enable-cache: true
+
+      - name: Run Python Tests
+        run: uv run pytest
+
   inspectCode:
     name: Inspect code
     needs: [ build ]
@@ -146,7 +163,7 @@ jobs:
   releaseDraft:
     name: Release draft
     if: github.event_name != 'pull_request'
-    needs: [ build, test, inspectCode, verify ]
+    needs: [ build, test, pythonTest, inspectCode, verify ]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hot reload (and ping) no longer stop working after a `.blend` file is opened or created in a running Blender session. The command-processing timer is now registered as `persistent=True` so it survives file loads, and a failing command can no longer unregister it. Previously the reload request was sent but silently ignored until Blender was restarted.
+
 ## [0.3.0] - 2026-05-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Fixed
 
-- Hot reload (and ping) no longer stop working after a `.blend` file is opened or created in a running Blender session. The command-processing timer is now registered as `persistent=True` so it survives file loads, and a failing command can no longer unregister it. Previously the reload request was sent but silently ignored until Blender was restarted.
+- Hot reload (and ping) no longer stop working after a `.blend` file is opened or created in a running Blender session. 
+    The command-processing timer is now registered as `persistent=True` so it survives file loads, and a failing command can no longer unregister it.
+    Previously the reload request was sent but silently ignored until Blender was restarted.
+- Console output (`print`) calls from blender add-ons now properly print to the pycharm run console.
 
 ## [0.3.0] - 2026-05-19
 

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+test-python:
+    uv run --group dev pytest
+
 docs-build:
     mkdir -p docs/en/theme && cp -r docs/theme/* docs/en/theme/
     mkdir -p docs/ja/theme && cp -r docs/theme/* docs/ja/theme/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,17 @@ dependencies = []
 [dependency-groups]
 dev = [
     "ruff>=0.15.1",
+    "pytest>=8",
 ]
+
+[tool.uv]
+# This repo is a Gradle/Kotlin plugin, not an installable Python package; the
+# Python here is dev-only tooling. Mark it virtual so `uv run` provisions the
+# environment without trying to build a root package.
+package = false
+
+[tool.pytest.ini_options]
+# probe_server.py and friends live under the plugin's resources, not on the
+# default import path. Add it so the tests can `import probe_server`.
+pythonpath = ["src/main/resources/python"]
+testpaths = ["src/test/python"]

--- a/src/main/resources/python/probe_server.py
+++ b/src/main/resources/python/probe_server.py
@@ -10,6 +10,16 @@ import traceback
 
 import bpy
 
+# When Blender is launched as a subprocess its stdout is a pipe, not a TTY, so
+# Python block-buffers it. That makes addon print() output invisible until
+# something flushes the buffer (e.g. a reload). Force line buffering so prints
+# appear live. Guarded because a replaced/older stream may lack reconfigure().
+try:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+except (AttributeError, ValueError):
+    pass
+
 HOST = "127.0.0.1"
 HEADER_SIZE = 64
 

--- a/src/main/resources/python/probe_server.py
+++ b/src/main/resources/python/probe_server.py
@@ -13,11 +13,13 @@ import bpy
 # When Blender is launched as a subprocess its stdout is a pipe, not a TTY, so
 # Python block-buffers it. That makes addon print() output invisible until
 # something flushes the buffer (e.g. a reload). Force line buffering so prints
-# appear live. Guarded because a replaced/older stream may lack reconfigure().
+# appear live. This is a best-effort tweak: a replaced/older/non-standard stream
+# may lack reconfigure() or reject the kwarg, so catch everything rather than let
+# a failure here abort import and take down the timer/socket registration.
 try:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
-except (AttributeError, ValueError):
+except Exception:
     pass
 
 HOST = "127.0.0.1"

--- a/src/main/resources/python/probe_server.py
+++ b/src/main/resources/python/probe_server.py
@@ -132,9 +132,15 @@ def main_thread_loop():
     while not execution_queue.empty():
         try:
             cmd = execution_queue.get_nowait()
-            process_command(cmd)
         except queue.Empty:
             break
+        # Never let a failing command propagate out of the timer; if it did,
+        # Blender would unregister the timer and the queue would stop draining.
+        try:
+            process_command(cmd)
+        except Exception as e:
+            log(f"Error processing command: {e}")
+            traceback.print_exc()
     return 0.1
 
 
@@ -261,7 +267,10 @@ def register():
         traceback.print_exc()
 
     if not bpy.app.timers.is_registered(main_thread_loop):
-        bpy.app.timers.register(main_thread_loop)
+        # persistent=True keeps the timer alive across .blend file loads.
+        # Without it, opening or creating a file unregisters the timer, so the
+        # queue stops draining and reload/ping commands are silently ignored.
+        bpy.app.timers.register(main_thread_loop, persistent=True)
         log("Main thread timer registered.")
 
     if addon_name:

--- a/src/test/python/conftest.py
+++ b/src/test/python/conftest.py
@@ -1,0 +1,103 @@
+"""Test fixtures for the in-Blender probe server.
+
+``probe_server.py`` runs inside Blender and does ``import bpy`` at module load,
+so it cannot be imported directly under a normal Python interpreter. These tests
+stand in a fake ``bpy`` module that reproduces the one behaviour we care about:
+Blender removes non-persistent ``bpy.app.timers`` whenever a .blend file is
+loaded. That is the exact rule the hot-reload regression hinged on, and faking
+it lets us test the fix without launching Blender.
+"""
+
+import os
+import sys
+import types
+
+import pytest
+
+# probe_server.py lives under the plugin resources, not on the import path.
+_PYTHON_SRC = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "main", "resources", "python")
+)
+if _PYTHON_SRC not in sys.path:
+    sys.path.insert(0, _PYTHON_SRC)
+
+
+class FakeTimers:
+    """Stand-in for ``bpy.app.timers``.
+
+    Records registrations and, like real Blender, drops every non-persistent
+    timer when a file is loaded (see :meth:`simulate_file_load`).
+    """
+
+    def __init__(self):
+        self.registered = []  # list of {"func", "persistent", "first_interval"}
+
+    def register(self, func, first_interval=None, persistent=False):
+        self.registered.append(
+            {"func": func, "persistent": persistent, "first_interval": first_interval}
+        )
+
+    def unregister(self, func):
+        self.registered = [r for r in self.registered if r["func"] is not func]
+
+    def is_registered(self, func):
+        return any(r["func"] is func for r in self.registered)
+
+    # --- test helpers ---------------------------------------------------
+    def simulate_file_load(self):
+        """Mimic Blender unloading non-persistent timers on file open/new."""
+        self.registered = [r for r in self.registered if r["persistent"]]
+
+    def call(self, func):
+        """Invoke a registered timer the way Blender's event loop would."""
+        for r in self.registered:
+            if r["func"] is func:
+                return r["func"]()
+        raise AssertionError(f"timer {func!r} is not registered")
+
+
+def _make_fake_bpy():
+    bpy = types.ModuleType("bpy")
+    bpy.app = types.SimpleNamespace(timers=FakeTimers())
+    bpy.context = types.SimpleNamespace(preferences=types.SimpleNamespace(addons={}))
+
+    class _AddonOps:
+        def __init__(self):
+            self.enabled = []
+
+        def addon_enable(self, module=None):
+            self.enabled.append(module)
+
+    bpy.ops = types.SimpleNamespace(preferences=_AddonOps())
+    return bpy
+
+
+# Inject the fake before any test imports probe_server.
+sys.modules.setdefault("bpy", _make_fake_bpy())
+
+
+@pytest.fixture
+def probe(monkeypatch):
+    """Import probe_server with a clean, isolated state for each test."""
+    import probe_server
+
+    # Fresh timer registry so tests don't leak registrations into each other.
+    probe_server.bpy.app.timers = FakeTimers()
+
+    # register() would otherwise bind a real TCP socket and spawn a thread.
+    monkeypatch.setattr(probe_server, "start_socket_server", lambda: None)
+
+    # Keep register() on its minimal path (no debugger attach, no auto-enable).
+    for var in (
+        "BLENDER_PROBE_DEBUG_PORT",
+        "BLENDER_PROBE_PYDEVD_PATH",
+        "BLENDER_PROBE_PROJECT_ROOT",
+        "BLENDER_PROBE_ADDON_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    while not probe_server.execution_queue.empty():
+        probe_server.execution_queue.get_nowait()
+    probe_server.server_running = False
+
+    return probe_server

--- a/src/test/python/test_probe_server_reload.py
+++ b/src/test/python/test_probe_server_reload.py
@@ -1,0 +1,78 @@
+"""Tests for the probe server's command loop, focused on the hot-reload
+regression: after a .blend file is opened/created, ping and reload commands
+must still be processed (previously the draining timer was silently removed).
+"""
+
+
+def test_communication_survives_file_switch(probe, capsys):
+    """The queue-draining timer must survive a file load and keep working.
+
+    This is the regression test for the bug where reload/ping stopped working
+    after opening or creating a new .blend file in a running Blender session.
+    """
+    probe.register()
+
+    timers = probe.bpy.app.timers
+    entry = next(r for r in timers.registered if r["func"] is probe.main_thread_loop)
+    # Persistence is what makes the timer survive a file load in Blender.
+    assert entry["persistent"] is True
+
+    # Commands are processed before the switch.
+    probe.execution_queue.put({"action": "ping"})
+    probe.main_thread_loop()
+    assert "Pong" in capsys.readouterr().out
+
+    # Open/create a .blend -> Blender drops non-persistent timers.
+    timers.simulate_file_load()
+
+    # The drain timer must still be registered (the actual bug was here).
+    assert timers.is_registered(probe.main_thread_loop), (
+        "main_thread_loop was unregistered on file load; "
+        "reload/ping would silently stop working until Blender restart"
+    )
+
+    # And communication still works after the switch.
+    probe.execution_queue.put({"action": "ping"})
+    timers.call(probe.main_thread_loop)
+    assert "Pong" in capsys.readouterr().out
+
+
+def test_bad_command_does_not_stop_draining(probe, capsys):
+    """A failing command must not propagate out of the timer.
+
+    If it did, Blender would unregister the timer and reproduce the same
+    silent-death symptom the persistence fix addresses.
+    """
+    probe.execution_queue.put("not-a-dict")  # process_command will raise
+    probe.execution_queue.put({"action": "ping"})
+
+    result = probe.main_thread_loop()
+
+    assert result == 0.1  # returned normally -> Blender keeps the timer alive
+    out = capsys.readouterr().out
+    assert "Error processing command" in out  # bad item was caught + logged
+    assert "Pong" in out  # the good item that followed still ran
+    assert probe.execution_queue.empty()  # queue fully drained past the failure
+
+
+def test_reload_command_dispatches_to_deep_reload(probe, monkeypatch):
+    """A reload command (what a file save sends) routes to deep_reload_addon."""
+    calls = []
+    monkeypatch.setattr(probe, "deep_reload_addon", lambda name: calls.append(name))
+
+    probe.execution_queue.put({"action": "reload", "module_name": "threed_bitmap"})
+    probe.main_thread_loop()
+
+    assert calls == ["threed_bitmap"]
+
+
+def test_reload_without_module_name_is_ignored(probe, monkeypatch):
+    """A reload missing module_name should be a no-op, not a crash."""
+    calls = []
+    monkeypatch.setattr(probe, "deep_reload_addon", lambda name: calls.append(name))
+
+    probe.execution_queue.put({"action": "reload"})
+    result = probe.main_thread_loop()
+
+    assert calls == []
+    assert result == 0.1

--- a/uv.lock
+++ b/uv.lock
@@ -9,13 +9,78 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.1" }]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.15.1" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
 
 [[package]]
 name = "ruff"


### PR DESCRIPTION
Fixes:
https://github.com/unclepomedev/blender_probe_for_pycharm/issues/112
https://github.com/unclepomedev/blender_probe_for_pycharm/issues/116

Blender communication properly persists when loading new blend files.
Added some python tests to check for this.

Also addressed the console output not flushing to pycharm. Now properly prints statements to the pycharm console as they are printed, not only on plugin reload.