### PR TITLE
Run Python tests with `dev` dependency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
           enable-cache: true
 
       - name: Run Python Tests
-        run: uv run pytest
+        run: uv run --group dev pytest
 
   inspectCode:
     name: Inspect code


### PR DESCRIPTION
This ensures `pytest` uses the dependencies specified in the `dev` group when executed via `uv`, aligning with current project dependency management.