### PR TITLE
Refactor Blender run state parameter building for testability

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,3 +11,6 @@ docs-build:
 
 docs-open:
     open docs/en/book/index.html && open docs/ja/book/index.html
+
+c:
+    ./gradlew check

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningState.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningState.kt
@@ -36,7 +36,7 @@ class BlenderRunningState(
          * Builds the Blender launch parameters. Extracted from [startProcess] so the
          * `--factory-startup` behavior can be unit tested without spawning a process.
          */
-        fun buildParameters(useFactoryStartup: Boolean, scriptPath: String): List<String> = buildList {
+        internal fun buildParameters(useFactoryStartup: Boolean, scriptPath: String): List<String> = buildList {
             if (useFactoryStartup) {
                 add("--factory-startup")
             }

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningState.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningState.kt
@@ -31,6 +31,22 @@ class BlenderRunningState(
     var cachedAddonName: String? = null
     var cachedSourceRoot: String? = null
 
+    companion object {
+        /**
+         * Builds the Blender launch parameters. Extracted from [startProcess] so the
+         * `--factory-startup` behavior can be unit tested without spawning a process.
+         */
+        fun buildParameters(useFactoryStartup: Boolean, scriptPath: String): List<String> = buildList {
+            if (useFactoryStartup) {
+                add("--factory-startup")
+            }
+            add("--python-exit-code")
+            add("1")
+            add("-P")
+            add(scriptPath)
+        }
+    }
+
     /**
      * Executes the process and attaches the console.
      *
@@ -63,15 +79,10 @@ class BlenderRunningState(
         val addonName = cachedAddonName ?: BlenderProbeUtils.detectAddonModuleName(project)
         val sourceRoot = cachedSourceRoot ?: BlenderProbeUtils.getAddonSourceRoot(project) ?: projectPath
 
-        val parameters = buildList {
-            if (BlenderSettings.getInstance(project).state.useFactoryStartup) {
-                add("--factory-startup")
-            }
-            add("--python-exit-code")
-            add("1")
-            add("-P")
-            add(scriptFile.absolutePath)
-        }
+        val parameters = buildParameters(
+            BlenderSettings.getInstance(project).state.useFactoryStartup,
+            scriptFile.absolutePath
+        )
 
         val cmd = GeneralCommandLine()
             .withExePath(blenderPath)

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningState.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningState.kt
@@ -32,10 +32,6 @@ class BlenderRunningState(
     var cachedSourceRoot: String? = null
 
     companion object {
-        /**
-         * Builds the Blender launch parameters. Extracted from [startProcess] so the
-         * `--factory-startup` behavior can be unit tested without spawning a process.
-         */
         internal fun buildParameters(useFactoryStartup: Boolean, scriptPath: String): List<String> = buildList {
             if (useFactoryStartup) {
                 add("--factory-startup")

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningState.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningState.kt
@@ -33,7 +33,7 @@ class BlenderTestRunningState(
     var cachedSourceRoot: String? = null
 
     companion object {
-        fun buildParameters(useFactoryStartup: Boolean, scriptPath: String, testDir: String): List<String> = buildList {
+        internal fun buildParameters(useFactoryStartup: Boolean, scriptPath: String, testDir: String): List<String> = buildList {
             add("-b")
             if (useFactoryStartup) {
                 add("--factory-startup")

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningState.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningState.kt
@@ -32,6 +32,19 @@ class BlenderTestRunningState(
     var cachedAddonName: String? = null
     var cachedSourceRoot: String? = null
 
+    companion object {
+        fun buildParameters(useFactoryStartup: Boolean, scriptPath: String, testDir: String): List<String> = buildList {
+            add("-b")
+            if (useFactoryStartup) {
+                add("--factory-startup")
+            }
+            add("-P")
+            add(scriptPath)
+            add("--")
+            add(testDir)
+        }
+    }
+
     /**
      * Executes the test process and attaches the console.
      *
@@ -74,16 +87,11 @@ class BlenderTestRunningState(
         val sourceRoot = cachedSourceRoot ?: BlenderProbeUtils.getAddonSourceRoot(project) ?: basePath
         val addonName = cachedAddonName ?: BlenderProbeUtils.detectAddonModuleName(project)
 
-        val parameters = buildList {
-            add("-b")
-            if (BlenderSettings.getInstance(project).state.useFactoryStartup) {
-                add("--factory-startup")
-            }
-            add("-P")
-            add(scriptFile.absolutePath)
-            add("--")
-            add(testDir)
-        }
+        val parameters = buildParameters(
+            BlenderSettings.getInstance(project).state.useFactoryStartup,
+            scriptFile.absolutePath,
+            testDir
+        )
 
         val cmd = GeneralCommandLine()
             .withExePath(blenderPath)

--- a/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/settings/BlenderSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/unclepomedev/blenderprobeforpycharm/settings/BlenderSettingsConfigurable.kt
@@ -11,7 +11,8 @@ import com.intellij.ui.dsl.builder.AlignX
 
 /**
  * Provides the configuration UI for Blender Probe settings.
- * Allows users to specify the path to the Blender executable.
+ * Lets users specify the Blender executable path and whether to launch
+ * Blender with `--factory-startup`.
  */
 class BlenderSettingsConfigurable(private val project: Project) : BoundConfigurable("Blender Probe") {
 

--- a/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningStateTest.kt
+++ b/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningStateTest.kt
@@ -6,24 +6,26 @@ import com.github.unclepomedev.blenderprobeforpycharm.settings.BlenderSettings
 class BlenderRunningStateTest : BaseBlenderTest() {
 
     fun testFactoryStartupFlagIncludedWhenEnabled() {
-        BlenderSettings.getInstance(project).state.useFactoryStartup = true
-
-        val params = BlenderRunningState.buildParameters(
-            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
-            scriptPath = "/tmp/probe_server.py"
-        )
-
-        assertTrue("--factory-startup should be present when the setting is enabled", "--factory-startup" in params)
+        assertFactoryStartupFlag(enabled = true, expected = true)
     }
 
     fun testFactoryStartupFlagOmittedWhenDisabled() {
-        BlenderSettings.getInstance(project).state.useFactoryStartup = false
+        assertFactoryStartupFlag(enabled = false, expected = false)
+    }
+
+    private fun assertFactoryStartupFlag(enabled: Boolean, expected: Boolean) {
+        val settings = BlenderSettings.getInstance(project)
+        settings.state.useFactoryStartup = enabled
 
         val params = BlenderRunningState.buildParameters(
-            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
+            useFactoryStartup = settings.state.useFactoryStartup,
             scriptPath = "/tmp/probe_server.py"
         )
 
-        assertFalse("--factory-startup should be absent when the setting is disabled", "--factory-startup" in params)
+        assertEquals(
+            "--factory-startup presence should match the setting (enabled=$enabled)",
+            expected,
+            "--factory-startup" in params
+        )
     }
 }

--- a/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningStateTest.kt
+++ b/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/app/BlenderRunningStateTest.kt
@@ -1,0 +1,29 @@
+package com.github.unclepomedev.blenderprobeforpycharm.run.app
+
+import com.github.unclepomedev.blenderprobeforpycharm.BaseBlenderTest
+import com.github.unclepomedev.blenderprobeforpycharm.settings.BlenderSettings
+
+class BlenderRunningStateTest : BaseBlenderTest() {
+
+    fun testFactoryStartupFlagIncludedWhenEnabled() {
+        BlenderSettings.getInstance(project).state.useFactoryStartup = true
+
+        val params = BlenderRunningState.buildParameters(
+            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
+            scriptPath = "/tmp/probe_server.py"
+        )
+
+        assertTrue("--factory-startup should be present when the setting is enabled", "--factory-startup" in params)
+    }
+
+    fun testFactoryStartupFlagOmittedWhenDisabled() {
+        BlenderSettings.getInstance(project).state.useFactoryStartup = false
+
+        val params = BlenderRunningState.buildParameters(
+            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
+            scriptPath = "/tmp/probe_server.py"
+        )
+
+        assertFalse("--factory-startup should be absent when the setting is disabled", "--factory-startup" in params)
+    }
+}

--- a/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningStateTest.kt
+++ b/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningStateTest.kt
@@ -1,0 +1,31 @@
+package com.github.unclepomedev.blenderprobeforpycharm.run.test
+
+import com.github.unclepomedev.blenderprobeforpycharm.BaseBlenderTest
+import com.github.unclepomedev.blenderprobeforpycharm.settings.BlenderSettings
+
+class BlenderTestRunningStateTest : BaseBlenderTest() {
+
+    fun testFactoryStartupFlagIncludedWhenEnabled() {
+        BlenderSettings.getInstance(project).state.useFactoryStartup = true
+
+        val params = BlenderTestRunningState.buildParameters(
+            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
+            scriptPath = "/tmp/run_tests.py",
+            testDir = "/tmp/tests"
+        )
+
+        assertTrue("--factory-startup should be present when the setting is enabled", "--factory-startup" in params)
+    }
+
+    fun testFactoryStartupFlagOmittedWhenDisabled() {
+        BlenderSettings.getInstance(project).state.useFactoryStartup = false
+
+        val params = BlenderTestRunningState.buildParameters(
+            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
+            scriptPath = "/tmp/run_tests.py",
+            testDir = "/tmp/tests"
+        )
+
+        assertFalse("--factory-startup should be absent when the setting is disabled", "--factory-startup" in params)
+    }
+}

--- a/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningStateTest.kt
+++ b/src/test/kotlin/com/github/unclepomedev/blenderprobeforpycharm/run/test/BlenderTestRunningStateTest.kt
@@ -6,26 +6,27 @@ import com.github.unclepomedev.blenderprobeforpycharm.settings.BlenderSettings
 class BlenderTestRunningStateTest : BaseBlenderTest() {
 
     fun testFactoryStartupFlagIncludedWhenEnabled() {
-        BlenderSettings.getInstance(project).state.useFactoryStartup = true
-
-        val params = BlenderTestRunningState.buildParameters(
-            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
-            scriptPath = "/tmp/run_tests.py",
-            testDir = "/tmp/tests"
-        )
-
-        assertTrue("--factory-startup should be present when the setting is enabled", "--factory-startup" in params)
+        assertFactoryStartupFlag(enabled = true, expected = true)
     }
 
     fun testFactoryStartupFlagOmittedWhenDisabled() {
-        BlenderSettings.getInstance(project).state.useFactoryStartup = false
+        assertFactoryStartupFlag(enabled = false, expected = false)
+    }
+
+    private fun assertFactoryStartupFlag(enabled: Boolean, expected: Boolean) {
+        val settings = BlenderSettings.getInstance(project)
+        settings.state.useFactoryStartup = enabled
 
         val params = BlenderTestRunningState.buildParameters(
-            useFactoryStartup = BlenderSettings.getInstance(project).state.useFactoryStartup,
+            useFactoryStartup = settings.state.useFactoryStartup,
             scriptPath = "/tmp/run_tests.py",
             testDir = "/tmp/tests"
         )
 
-        assertFalse("--factory-startup should be absent when the setting is disabled", "--factory-startup" in params)
+        assertEquals(
+            "--factory-startup presence should match the setting (enabled=$enabled)",
+            expected,
+            "--factory-startup" in params
+        )
     }
 }


### PR DESCRIPTION
Extracts the Blender launch parameter construction logic into static methods to allow unit testing of argument handling, specifically the `--factory-startup` flag, without needing to spawn a Blender process.

Adds a `just c` recipe for running `./gradlew check`.